### PR TITLE
Add tracker object to manage WinSock DLL lifetime.

### DIFF
--- a/src/Windows/CWindowsWinsockServerSocket.cpp
+++ b/src/Windows/CWindowsWinsockServerSocket.cpp
@@ -6,6 +6,7 @@
 
 #include <WS2tcpip.h>
 #include "CWindowsWinsockStreamSocket.hpp"
+#include "CWindowsWinsockTracker.hpp"
 
 #include <IThread.hpp>
 #include <IGarbageCollector.hpp>
@@ -20,26 +21,16 @@ namespace Insanity
 	}
 
 	CWindowsWinsockServerSocket::CWindowsWinsockServerSocket(u16 port) :
-		_sock(0)//, _ref(0)
+		_sock(0)
 	{
-		{
-			WSAData unused;
-
-			//check this for return values:
-			//	WSASYSNOTREADY (The only one that may be the case, but what do I do about it?)
-			//	WSAVERNOTSUPPORTED (version requested not supported, no.)
-			//	WSAEPROCLIM (proclimit for winsock reached, would be bullshit if this is the case)
-			//	WSAEFAULT (lpwsadata not valid pointer, shouldn't be the case)
-			//	0 means it worked.
-			WSAStartup(MAKEWORD(2,2),&unused);
-		}
+		CWindowsWinsockTracker::Retain();
 		if(!Listen(port)) std::cout << "Listen Error." << std::endl;
 	}
 	CWindowsWinsockServerSocket::~CWindowsWinsockServerSocket()
 	{
 		if(_sock) Close();
 
-		WSACleanup();
+		CWindowsWinsockTracker::Release();
 	}
 
 	//=====================================================
@@ -128,27 +119,6 @@ namespace Insanity
 	{
 		return (_sock != 0);
 	}
-
-	//=====================================================
-	//Interface: IObject
-	//=====================================================
-	//void CWindowsWinsockServerSocket::Retain()
-	//{
-	//	++_ref;
-	//}
-	//void CWindowsWinsockServerSocket::Release()
-	//{
-	//	if(_ref == 0) return;
-	//	--_ref;
-	//}
-	//u64 CWindowsWinsockServerSocket::GetReferenceCount() const
-	//{
-	//	return _ref;
-	//}
-	//void CWindowsWinsockServerSocket::Delete()
-	//{
-	//	delete this;
-	//}
 }
 
 #endif

--- a/src/Windows/CWindowsWinsockStreamSocket.cpp
+++ b/src/Windows/CWindowsWinsockStreamSocket.cpp
@@ -6,6 +6,7 @@
 
 #include <WS2tcpip.h>
 #include <IByteArray.hpp>
+#include "CWindowsWinsockTracker.hpp"
 
 #include <IThread.hpp>
 #include <IGarbageCollector.hpp>
@@ -20,32 +21,21 @@ namespace Insanity
 	}
 
 	CWindowsWinsockStreamSocket::CWindowsWinsockStreamSocket(char const * host, u16 port) :
-		_sock(0)//, _ref(0)
+		_sock(0)
 	{
-		{
-			WSAData unused;
-			WSAStartup(MAKEWORD(2,2),&unused);
-			//No ill effects from multiple calls
-			//	Just call WSACleanup an equal number of times.
-		}
+		CWindowsWinsockTracker::Retain();
 		Connect(host,port);
 	}
 	CWindowsWinsockStreamSocket::CWindowsWinsockStreamSocket(SOCKET accepted) :
-		_sock(accepted)//, _ref(0)
+		_sock(accepted)
 	{
-		//since it always cleans up in the dtor, need to startup, even though it will always already have been started.
-		{
-			WSAData unused;
-			WSAStartup(MAKEWORD(2,2),&unused);
-		}
+		CWindowsWinsockTracker::Retain();
 	}
 	CWindowsWinsockStreamSocket::~CWindowsWinsockStreamSocket()
 	{
 		if(_sock) Close();
 
-		//startup and cleanup manage a reference counter in the Winsock DLL
-		//when it goes to 0, cleanup actually occurs.
-		WSACleanup();
+		CWindowsWinsockTracker::Release();
 	}
 
 	//=====================================================
@@ -137,27 +127,6 @@ namespace Insanity
 	{
 		return (_sock != 0);
 	}
-
-	//=====================================================
-	//Interface: IObject
-	//=====================================================
-	//void CWindowsWinsockStreamSocket::Retain()
-	//{
-	//	++_ref;
-	//}
-	//void CWindowsWinsockStreamSocket::Release()
-	//{
-	//	if(_ref == 0) return;
-	//	--_ref;
-	//}
-	//u64 CWindowsWinsockStreamSocket::GetReferenceCount() const
-	//{
-	//	return _ref;
-	//}
-	//void CWindowsWinsockStreamSocket::Delete()
-	//{
-	//	delete this;
-	//}
 }
 
 #endif

--- a/src/Windows/CWindowsWinsockTracker.cpp
+++ b/src/Windows/CWindowsWinsockTracker.cpp
@@ -1,0 +1,30 @@
+#define INSANITY_BUILDING_LIBRARY
+
+#include "CWindowsWinsockTracker.hpp"
+#include <WinSock2.h>
+
+namespace Insanity
+{
+	u64 CWindowsWinsockTracker::s_ref = 0;
+	
+	void CWindowsWinsockTracker::Retain()
+	{
+		//if s_ref is 1 after increment
+		if(++s_ref == 1)
+		{
+			WSADATA unused;
+			WSAStartup(MAKEWORD(2,2), &unused);
+		}
+	}
+	void CWindowsWinsockTracker::Release()
+	{
+		//if s_ref is already 0, don't underflow.
+		if(s_ref == 0) return;
+		
+		//if s_ref is 0 after decrement
+		if(--s_ref == 0)
+		{
+			WSACleanup();
+		}
+	}
+}

--- a/src/Windows/CWindowsWinsockTracker.hpp
+++ b/src/Windows/CWindowsWinsockTracker.hpp
@@ -1,0 +1,23 @@
+#ifndef INSANITY_IMPLEMENTATION_WINDOWS_WINSOCK_TRACKER
+#define INSANITY_IMPLEMENTATION_WINDOWS_WINSOCK_TRACKER
+
+#include <Constants.hpp>
+
+namespace Insanity
+{
+	//static class for keeping track of existing references to Winsock.
+	class CWindowsWinsockTracker final
+	{
+	private:
+		//Should not be instantiated, ctor and dtor made private.
+		CWindowsWinsockTracker();
+		~CWindowsWinsockTracker();
+	
+		static u64 s_ref;
+	public:
+		static void Retain();
+		static void Release();
+	};
+}
+
+#endif


### PR DESCRIPTION
Add static class CWindowsWinsockTracker, which counts references to WinSock DLL, initializing on first Retain and shutting down on zeroing Release.

Requires conformance tests with:
*CWindowsWinsockStreamSocket ctor and dtor
*CWindowsWinsockServerSocket ctor and dtor
